### PR TITLE
Update the printerr function to `exit(1)`

### DIFF
--- a/cloudfire/available_polygons.py
+++ b/cloudfire/available_polygons.py
@@ -23,7 +23,7 @@ valid_historical_years_years = ["2014", "2015", "2016", "2017", "2018", "2019", 
 
 def printerr(msg):
   print(msg)
-  exit()
+  exit(1)
 
 def str2bool(v):
     if isinstance(v, bool):

--- a/cloudfire/elmfire.py
+++ b/cloudfire/elmfire.py
@@ -37,7 +37,7 @@ import pytz
 
 def printerr(msg):
   print(msg)
-  exit()
+  exit(1)
 
 def str2bool(v):
     if isinstance(v, bool):


### PR DESCRIPTION
Updates the `printerr` function to exit with an exit code of 1.