### PR TITLE
Simplified docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 as intermediate
+FROM ubuntu:22.04 AS intermediate
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p /elmfire/elmfire /scratch/elmfire && \
@@ -37,7 +37,7 @@ RUN apt-get purge -y build-essential && \
     apt-get clean && \
     rm -f -r /var/lib/apt/lists/*
 
-WORKDIR /
+WORKDIR /elmfire
 
 ENV ELMFIRE_VER=2024.0326
 ENV ELMFIRE_BASE_DIR=/elmfire/elmfire

--- a/build/docker/01-build.sh
+++ b/build/docker/01-build.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-CWD=$(pwd)
-ELMFIRE_CLEAN=$HOME/elmfire_clean
+cd ../..
 
-rm -f -r $CWD/temp
-mkdir -p $CWD/temp/elmfire
-
-cd $ELMFIRE_CLEAN
-git pull
-cp -f -r * $CWD/temp/elmfire/
-
-cd $CWD
 docker build -t elmfire .
-
-rm -f -r $CWD/temp
 
 exit 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  elmfire:
+    container_name: client
+    hostname: client
+    build: .
+    stdin_open: true # docker run -i
+    tty: true        # docker run -t
+    working_dir: /elmfire/elmfire
+    entrypoint: bash
+    volumes:
+      - ./docker_shared_folder:/elmfire/elmfire/docker_shared_folder
+    environment:
+      - USE_SLURM=no


### PR DESCRIPTION
### Purpose

This PR updates the docker workflow by simplifying the copying of the repo code into the container. 

First the Docker file is moved up to the top level of the repo. Running the Docker process at this level allows for copying all the repo code. This eliminates the need for the current process that creates a temporary folder and clones another copy of the repo.

I've temporarily left a copy of the updated Dockerfile in the old location `/elmfire/build/docker` as well so you can more easily see the minor changes I've made.

With the addition of a Docker compose file, building and interacting with the container is simplified:

To build the ELMFIRE container use:
```
docker compose build
```

To bring up a bash shell within the container to run ELMFIRE use:
```
docker compose run elmfire
```

Files can be in shared between the host machine and the container by using the `docker_shared_folder`, which is mounted at the top level of ELMFIRE repo on the host machine and also mounted at repo location within the container.




