### PR TITLE
Bugfix: Uninitialized J2 in GET_BILINEAR_INTERPOLATE_COEFFS

### DIFF
--- a/build/source/elmfire_subs.f90
+++ b/build/source/elmfire_subs.f90
@@ -811,7 +811,7 @@ I2 = MAX ( MIN(I1 + 1, NCOL_WX), 1 )
 
 J1 = 1 + NINT( (CY - YLL_WX) / CELLSIZE_WX )
 J1 = MAX ( MIN(J1,     NROW_WX), 1 )
-J2 = MAX ( MIN(J2 + 1, NROW_WX), 1 )
+J2 = MAX ( MIN(J1 + 1, NROW_WX), 1 )
 
 X1 = XLL_WX + (REAL(I1) - 0.5) * CELLSIZE_WX
 X2 = XLL_WX + (REAL(I2) - 0.5) * CELLSIZE_WX


### PR DESCRIPTION
Previously, J2 had invalid grid index interpolation in some edge cases due to typo. This commit fixes typo J2 -> J1. Can compare to code chunk above for consistency with I1, I2 calculations. 