### PR TITLE
Formatting changes to spotting user guide

### DIFF
--- a/docs/user_guide/spotting.rst
+++ b/docs/user_guide/spotting.rst
@@ -39,7 +39,7 @@ related to fireline intensity (:math:`{\dot{Q}'}`) and 20-ft wind speed
 
 .. math::
 
-   m = a{\dot{Q}'^b}u^c_{20}
+   m = a{\dot{Q}'^b}u^c_{20} \\
    v = md
 
 The empirical parameters :math:`{a}`, :math:`{b}`, :math:`{c}`, and 
@@ -61,9 +61,7 @@ The normalized mean (:math:`{\mu}`) and standard deviation
 
 .. math::
 
-   \mu = ln(\frac{m^2}{\sqrt{v + m^2}})
-
-.. math::
+   \mu = ln(\frac{m^2}{\sqrt{v + m^2}}) \\
    \sigma = \sqrt{ln(1 + \frac{v}{m^2})}
 
 Spotting distance (:math:`{x}`) is calculated probabilistically from a 

--- a/docs/user_guide/spotting.rst
+++ b/docs/user_guide/spotting.rst
@@ -69,7 +69,7 @@ lognormal distribution:
 
 .. math::
 
-   f(x) = \frac{1}{\sqrt{{2\pi}}\sigma x}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)
+   f(x) = \frac{1}{x \sigma\sqrt{{2\pi}}}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)
 
 By default, when ``ENABLE_SPOTTING = .TRUE.``, only pixels that burn as 
 passive or active crown fire trigger the spotting algorithm. The keyword 

--- a/docs/user_guide/spotting.rst
+++ b/docs/user_guide/spotting.rst
@@ -62,6 +62,8 @@ The normalized mean (:math:`{\mu}`) and standard deviation
 .. math::
 
    \mu = ln(\frac{m^2}{\sqrt{v + m^2}})
+
+.. math::
    \sigma = \sqrt{ln(1 + \frac{v}{m^2})}
 
 Spotting distance (:math:`{x}`) is calculated probabilistically from a 
@@ -69,7 +71,7 @@ lognormal distribution:
 
 .. math::
 
-   f(x) = \frac{1}{\sqrt{{2\pi}\sigma x}}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)
+   f(x) = \frac{1}{\sqrt{{2\pi}}\sigma x}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)
 
 By default, when ``ENABLE_SPOTTING = .TRUE.``, only pixels that burn as 
 passive or active crown fire trigger the spotting algorithm. The keyword 


### PR DESCRIPTION
This pull request addresses a small typo in the definition of the log normal PDF. It also adds newline breaks within two `.. math::` blocks to improve readability. 

Currently, the user guide describes the PDF of a log-normal as: 

$f(x) = \frac{1}{\sqrt{{2\pi}\sigma x}}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)$

I believe the error occurs in the square root term. I believe it should be written 

$f(x) = \frac{1}{x \sigma\sqrt{{2\pi}}}exp(-\frac{1}{2}(\frac{lnx-\mu}{\sigma})^2)$,

with the x and $\sigma$ terms outside of the square root. This conforms with [other definitions](https://statproofbook.github.io/P/lognorm-pdf.html) I've come across. Maybe this is just a typo? 

It also looks like line wrapping didn't work in the `.. math::` blocks, which I tried to address. I didn't rebuild the docs but a quick look using a rst document previewer makes me think my proposed change (adding `\\`) should work. 